### PR TITLE
Added associated entity "Methods" to "Calculate climate indices"

### DIFF
--- a/data-sources/mohc-cvs/data/operations.json
+++ b/data-sources/mohc-cvs/data/operations.json
@@ -862,6 +862,10 @@
           ]
         },
         "Description": "The operation that computes relevant climate indices from both observational and climate model datasets. Possibly, emulators could be used to obtain relevant information for index computation.",
+        "AssociatedData": {
+          "type": "uri",
+          "cv": "Method"
+        },
         "Name": "Compute climate indices"
       },
       {


### PR DESCRIPTION
I think the original idea was to add this task as an action item. However, it is often necessary to provide a statistic or indicator from variables—we do not have the ability to do so at the identification stage. We can add that this step is only necessary if suitable pre-calculated indices (like Climdex, Climate ADAPT, etc.) are not available.
We might also need to add "Method" instead of "Text" for "Select impact model," because it is possible to use simple transfer functions like linear (including multilinear) and quantile regression. Of course, it will not be enough for most applications, but it might be beneficial for some.